### PR TITLE
retrieve id of trips for GET /trips

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -64,9 +64,9 @@ app.use((err, req, res, next) => {
 // Starting the server
 
 // Use for Local Testing
-app.listen(8080, () => {
-  console.log(`Listening on ${8080}`);
-});
+// app.listen(8080, () => {
+//   console.log(`Listening on ${8080}`);
+// });
 
 
 // Exporting for unit testing purposesS

--- a/functions/index.js
+++ b/functions/index.js
@@ -64,9 +64,9 @@ app.use((err, req, res, next) => {
 // Starting the server
 
 // Use for Local Testing
-// app.listen(8080, () => {
-//   console.log(`Listening on ${8080}`);
-// });
+app.listen(8080, () => {
+  console.log(`Listening on ${8080}`);
+});
 
 
 // Exporting for unit testing purposesS

--- a/functions/routes/tripRoutes.js
+++ b/functions/routes/tripRoutes.js
@@ -25,11 +25,13 @@ tripRouter.get("/trips", decodeToken, async (req, res, next) => {
   try {
     const userRef = db.collection("Users").doc(req.user);
     const snap = await db.collection("Trips").where("user", "==", userRef).get();
-    // const snap = await db.collection('Trips').get()
     const data = [];
     if (!snap.empty) {
       snap.forEach((doc) => {
-        data.push(doc.data());
+        console.log(doc.id)
+        let pushData = doc.data()
+        pushData.id = doc.id
+        data.push(pushData);
       });
       return res.status(200).json(data);
     } else {


### PR DESCRIPTION
urgent hotfix to make GET /trips endpoint return firestore ID of the trips along with the data of the trip